### PR TITLE
enhancement: make use of defer error values

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,9 +31,7 @@ func NewClient(options ...ConfigOption) (Client, error) {
 }
 
 // Do is the main function of the client that makes the ICAP request
-func (c *Client) Do(req Request) (Response, error) {
-	var err error
-
+func (c *Client) Do(req Request) (res Response, err error) {
 	// establish connection to the icap server
 	err = c.conn.Connect(req.ctx, req.URL.Host)
 	if err != nil {
@@ -57,15 +55,15 @@ func (c *Client) Do(req Request) (Response, error) {
 		return Response{}, err
 	}
 
-	resp, err := toClientResponse(bufio.NewReader(strings.NewReader(string(dataRes))))
+	res, err = toClientResponse(bufio.NewReader(strings.NewReader(string(dataRes))))
 	if err != nil {
 		return Response{}, err
 	}
 
 	// check if the message is fully done scanning or if it needs to be sent another chunk
-	done := !(resp.StatusCode == http.StatusContinue && !req.bodyFittedInPreview && req.previewSet)
+	done := !(res.StatusCode == http.StatusContinue && !req.bodyFittedInPreview && req.previewSet)
 	if done {
-		return resp, nil
+		return res, nil
 	}
 
 	// get the remaining body bytes

--- a/request.go
+++ b/request.go
@@ -55,10 +55,9 @@ func NewRequest(ctx context.Context, method, urlStr string, httpReq *http.Reques
 
 // SetPreview sets the preview bytes in the icap header
 // todo: defer close error
-func (r *Request) SetPreview(maxBytes int) error {
+func (r *Request) SetPreview(maxBytes int) (err error) {
 	var bodyBytes []byte
 	var previewBytes int
-	var err error
 
 	// receiving the body bites to determine the preview bytes depending on the request ICAP method
 	if r.Method == MethodREQMOD {


### PR DESCRIPTION
defer calls can only write/change outer scope variables if the value is a named return,
if the value variable is defined from the inner function scope, changes are not possible.

e.g. 

```go
package main

import (
	"errors"
	"fmt"
)

func valid() (err error){
	err = errors.New("an error")

	defer func(){
		err = nil
	}()

	return err
}

func invalid() error{
	err := errors.New("an error")

	defer func(){
		err = nil
	}()

	return err
}

func main() {
	fmt.Println(valid(), invalid())
}
```

prints:
```shell
<nil> an error
```